### PR TITLE
Update test commands for curl and wget

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,8 +24,8 @@ File me [[https://github.com/dennyzhang/cheatsheet.dennyzhang.com/issues][Issues
 ** Common Commands
 | Name                                 | Command                                                                                   |
 |--------------------------------------+-------------------------------------------------------------------------------------------|
-| Run curl test temporarily            | =kubectl run --rm mytest --image=yauritux/busybox-curl -it=                               |
-| Run wget test temporarily            | =kubectl run --rm mytest --image=busybox -it=                                             |
+| Run curl test temporarily            | =kubectl run --generator=run-pod/v1 --rm mytest --image=yauritux/busybox-curl -it=        |
+| Run wget test temporarily            | =kubectl run --generator=run-pod/v1 --rm mytest --image=busybox -it wget=                 |
 | Run nginx deployment with 2 replicas | =kubectl run my-nginx --image=nginx --replicas=2 --port=80=                               |
 | Run nginx pod and expose it          | =kubectl run my-nginx --restart=Never --image=nginx --port=80 --expose=                   |
 | Run nginx deployment and expose it   | =kubectl run my-nginx --image=nginx --port=80 --expose=                                   |


### PR DESCRIPTION
The previous command will create a deployment instead of a pod for one-time jobs. There's also no indication that the user should pass `curl` or `wget` after it, so running this command will result in an error.
```
$ kubectl run --generator=run-pod/v1 --rm mytest --image=yauritux/busybox-curl:latest -it http://google.com
```

The result will be this:
```
$ kubectl describe pod mytest
... Error: failed to start container "mytest": Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"http://google.com\": stat http://google.com: no such file or directory": unknown
...
```

I modified the command so the user can just append it with any `curl` or `wget` options.

Here is for `curl`:
```
$ kubectl run --generator=run-pod/v1 --rm mytest --image=curlimages/curl -it http://google.com
If you don't see a command prompt, try pressing enter.
Error attaching, falling back to logs:
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
pod "mytest" deleted
```

And here's for `wget`:
```
$ kubectl run --generator=run-pod/v1 --rm mytest --image=busybox -it wget http://google.com
If you don't see a command prompt, try pressing enter.
saving to 'index.html'
index.html           100% |**********************************************************************************************************************************************************************************************| 15773  0:00:00 ETA
'index.html' saved
Session ended, resume using 'kubectl attach mytest -c mytest -i -t' command when the pod is running
pod "mytest" deleted
```